### PR TITLE
fix: Correct syntax error in reporting module

### DIFF
--- a/js/modules/reporting.js
+++ b/js/modules/reporting.js
@@ -77,7 +77,7 @@ const Reporting = {
       console.error('Error generating royalty summary report:', error);
       showToast('Failed to generate report. See console for details.', 'error');
     }
-  }
+  },
 
   // Other report generation methods will be added here
   async generateEntityPerformanceReport() {


### PR DESCRIPTION
This commit fixes a JavaScript syntax error in `js/modules/reporting.js`. A missing comma between two method definitions within the `Reporting` object literal caused a `SyntaxError: Unexpected token 'async'`.

The comma has been added, and the application should now load correctly.