### PR TITLE
feat: Enhance GIS dashboard with layers, custom markers, and legend

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -101,7 +101,7 @@ class App {
         this.documentManagement = DocumentManagement;
         this.reporting = Reporting;
         this.royaltyRecords = RoyaltyRecords;
-        this.gisDashboard = new GisDashboard();
+        this.gisDashboard = new GisDashboard(this.state.contracts);
 
         // Initialize app
         this.initializeServices();

--- a/js/modules/GisDashboard.js
+++ b/js/modules/GisDashboard.js
@@ -5,9 +5,32 @@
  * including the Leaflet map, tile layers, and mine markers.
  */
 export class GisDashboard {
-    constructor() {
+    constructor(contracts) {
         this.map = null;
         this.mineLocations = [];
+        this.contracts = contracts || [];
+        this.layers = {
+            mines: L.layerGroup(),
+            quarries: L.layerGroup()
+        };
+
+        this.mineIcon = new L.Icon({
+            iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-red.png',
+            shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+            iconSize: [25, 41],
+            iconAnchor: [12, 41],
+            popupAnchor: [1, -34],
+            shadowSize: [41, 41]
+        });
+
+        this.quarryIcon = new L.Icon({
+            iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-blue.png',
+            shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+            iconSize: [25, 41],
+            iconAnchor: [12, 41],
+            popupAnchor: [1, -34],
+            shadowSize: [41, 41]
+        });
     }
 
     /**
@@ -27,9 +50,19 @@ export class GisDashboard {
             attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         }).addTo(this.map);
 
+        const overlayMaps = {
+            "Mines": this.layers.mines,
+            "Quarries": this.layers.quarries
+        };
+
+        L.control.layers(null, overlayMaps).addTo(this.map);
+        this.layers.mines.addTo(this.map);
+        this.layers.quarries.addTo(this.map);
+
         console.log('GIS Dashboard initialized.');
 
         this.loadMines();
+        this.addLegend();
     }
 
     /**
@@ -39,8 +72,20 @@ export class GisDashboard {
     addMineMarkers(mines) {
         this.mineLocations = mines;
         this.mineLocations.forEach(mine => {
-            const marker = L.marker([mine.lat, mine.lon]).addTo(this.map);
-            marker.bindPopup(`<b>${mine.name}</b>`);
+            const isQuarry = mine.name.toLowerCase().includes('quarry');
+            const icon = isQuarry ? this.quarryIcon : this.mineIcon;
+            const layer = isQuarry ? this.layers.quarries : this.layers.mines;
+
+            const contract = this.contracts.find(c => c.entity === mine.name);
+            let popupContent = `<b>${mine.name}</b>`;
+
+            if (contract) {
+                const status = new Date(contract.startDate) < new Date() ? 'Active' : 'Pending';
+                popupContent += `<br>Mineral: ${contract.mineral}<br>Status: ${status}`;
+            }
+
+            const marker = L.marker([mine.lat, mine.lon], { icon: icon }).addTo(layer);
+            marker.bindPopup(popupContent);
         });
     }
 
@@ -58,5 +103,22 @@ export class GisDashboard {
         ];
 
         this.addMineMarkers(mines);
+    }
+
+    addLegend() {
+        const legend = L.control({ position: 'bottomright' });
+
+        legend.onAdd = () => {
+            const div = L.DomUtil.create('div', 'info legend');
+            let labels = ['<strong>Legend</strong>'];
+
+            labels.push(`<img src="${this.mineIcon.options.iconUrl}" style="width: 12px; height: 20px;"> Mine`);
+            labels.push(`<img src="${this.quarryIcon.options.iconUrl}" style="width: 12px; height: 20px;"> Quarry`);
+
+            div.innerHTML = labels.join('<br>');
+            return div;
+        };
+
+        legend.addTo(this.map);
     }
 }

--- a/royalties.css
+++ b/royalties.css
@@ -3646,3 +3646,16 @@ nav ul li a span.notification-badge {
   padding-top: 1rem;
   border-top: 1px solid var(--border-color);
 }
+
+.legend {
+    padding: 6px 8px;
+    font: 14px/16px Arial, Helvetica, sans-serif;
+    background: white;
+    background: rgba(255,255,255,0.8);
+    box-shadow: 0 0 15px rgba(0,0,0,0.2);
+    border-radius: 5px;
+}
+
+.legend img {
+    vertical-align: middle;
+}


### PR DESCRIPTION
This commit enhances the GIS dashboard with several new features:

- **Map Layers**: Adds layer controls to the map, allowing users to toggle between 'Mines' and 'Quarries' layers.
- **Custom Markers**: Implements custom icons for mines (red) and quarries (blue) to visually differentiate them on the map.
- **Enhanced Popups**: Popups now display additional information for each mine, including the primary mineral and operational status, sourced from the application's state.
- **Map Legend**: A legend has been added to the map to explain the different marker icons.