### PR TITLE
Refactor 'Forgot Password' flow to use notifications

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -377,17 +377,13 @@ class App {
             e.preventDefault();
             const email = e.target.elements['reset-email'].value;
             if (email) {
-                document.getElementById('forgot-password-section').style.display = 'none';
-                document.getElementById('forgot-password-confirmation').style.display = 'flex';
+                // In a real app, an API call would be made here.
+                // For the demo, we just show a notification and return to login.
+                this.notificationManager.show('If an account with that email exists, a password reset link has been sent.', 'success');
+                this.showLogin();
             } else {
                 this.notificationManager.show('Please enter your email address.', 'error');
             }
-        });
-
-        document.getElementById('back-to-login-from-confirmation')?.addEventListener('click', (e) => {
-            e.preventDefault();
-            this.showLogin();
-            document.getElementById('forgot-password-confirmation').style.display = 'none';
         });
 
         // Communication Hub listeners

--- a/royalties.html
+++ b/royalties.html
@@ -125,20 +125,6 @@
     </div>
   </section>
 
-  <!-- Forgot Password Confirmation -->
-    <section class="forgot-password-section" id="forgot-password-confirmation" style="display: none;">
-        <div class="login-container">
-            <div class="login-header">
-                <div class="login-logo" aria-label="Mining Royalties Manager Logo">MR</div>
-                <h2>Check Your Email</h2>
-                <p>We've sent a password reset link to the email address you provided.</p>
-            </div>
-            <div class="login-footer">
-                <a href="#" id="back-to-login-from-confirmation" class="btn btn-primary btn-large">Back to Sign In</a>
-            </div>
-        </div>
-    </section>
-
   <!-- Main App -->
   <div class="app-container" id="app-container" style="display: none;">
     <!-- Sidebar -->


### PR DESCRIPTION
This commit updates the 'Forgot Password' functionality to provide a better user experience.

Previously, submitting the 'Forgot Password' form would navigate the user to a separate confirmation page. This change removes the confirmation page and instead displays a success notification to the user, after which they are returned to the login screen.

This change aligns the application's behavior with the expectations set in the Playwright test `tests/forgot_password.spec.js`.

The following changes were made:
- Modified `js/app.js` to show a notification and redirect to the login page on 'Forgot Password' form submission.
- Removed the now-obsolete `#forgot-password-confirmation` section from `royalties.html`.