### PR TITLE
Fix: Runtime error in showLogin function

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -871,7 +871,6 @@ class App {
     showLogin() {
         document.getElementById('login-section').style.display = 'flex';
         document.getElementById('forgot-password-section').style.display = 'none';
-        document.getElementById('forgot-password-confirmation').style.display = 'none';
         document.getElementById('app-container').style.display = 'none';
     }
 


### PR DESCRIPTION
This commit fixes a runtime error that occurred in the `showLogin` function. The error was caused by an attempt to access the `#forgot-password-confirmation` element, which was removed in a previous commit.

This fix removes the line of code that was referencing the non-existent element, resolving the `TypeError`.