### PR TITLE
Fix: Runtime error in showLogin and showForgotPassword

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -877,7 +877,6 @@ class App {
     showForgotPassword() {
         document.getElementById('login-section').style.display = 'none';
         document.getElementById('forgot-password-section').style.display = 'flex';
-        document.getElementById('forgot-password-confirmation').style.display = 'none';
         document.getElementById('app-container').style.display = 'none';
     }
 


### PR DESCRIPTION
This commit fixes a runtime error that occurred in the `showLogin` and `showForgotPassword` functions. The error was caused by an attempt to access the `#forgot-password-confirmation` element, which was removed in a previous commit.

This fix removes the lines of code that were referencing the non-existent element, resolving the `TypeError`.