### PR TITLE
feat: Extend pagination to all management sections

### DIFF
--- a/royalties.html
+++ b/royalties.html
@@ -532,6 +532,7 @@
               </tbody>
             </table>
           </div>
+          <div class="table-pagination" id="contract-management-pagination"></div>
         </div>
       </section>
 
@@ -1155,6 +1156,7 @@
               </tbody>
             </table>
           </div>
+          <div class="table-pagination" id="lease-management-pagination"></div>
         </div>
       </section>
 
@@ -1240,6 +1242,7 @@
               </tbody>
             </table>
           </div>
+          <div class="table-pagination" id="expense-tracking-pagination"></div>
         </div>
       </section>
 
@@ -1303,6 +1306,7 @@
               </tbody>
             </table>
           </div>
+          <div class="table-pagination" id="document-management-pagination"></div>
         </div>
       </section>
 


### PR DESCRIPTION
- Integrate the reusable Pagination component into Contract, Lease, Expense, and Document management modules.
- Add mock data to each module's `dbService` to demonstrate pagination.
- Refactor the `render` methods in each module to be page-aware, slicing the data array before rendering.
- Update CRUD operations in each module to refresh the view to page 1.
- Add the required pagination `div` containers to `royalties.html` for each section.