### PR TITLE
fix: Increment IndexedDB version to fix schema error

### DIFF
--- a/js/services/database.service.js
+++ b/js/services/database.service.js
@@ -6,7 +6,7 @@
 class DatabaseService {
     constructor() {
         this.dbName = 'RoyaltiesDB';
-        this.version = 1;
+        this.version = 2; // Incremented version to trigger upgrade
         this.stores = {
             royalties: 'royalties',
             users: 'users',


### PR DESCRIPTION
Increment the database version in `database.service.js` from 1 to 2.

This change is necessary to trigger the `onupgradeneeded` event for existing users, which will create the recently added object stores (`leases`, `contracts`, `expenses`, `documents`). This resolves the `NotFoundError` that occurs on startup when the application tries to access these non-existent stores.