### PR TITLE
fix(gis): Add missing leaflet.draw dependency

### DIFF
--- a/royalties.html
+++ b/royalties.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.css" />
   <link rel="stylesheet" href="royalties.css">
   <link rel="stylesheet" href="css/user-management-enhanced.css">
   <link rel="stylesheet" href="css/contract-management-enhanced.css">
@@ -17,6 +18,7 @@
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
   <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/leaflet-geometryutil@0.10.1/src/leaflet.geometryutil.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.js"></script>
   <script src="js/bcrypt.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>

--- a/tests/gis_dashboard.spec.js
+++ b/tests/gis_dashboard.spec.js
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('GIS Dashboard', () => {
+  let page;
+  const consoleErrors = [];
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    page.on('console', msg => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+    await page.goto('http://localhost:8000/royalties.html');
+
+    // Wait for the login form to be visible
+    await page.waitForSelector('#login-form');
+
+    // Perform login
+    await page.fill('#username', 'admin');
+    await page.fill('#password', 'demo123');
+    await page.click('button[type="submit"]');
+
+    // Wait for the main app container to be visible
+    await page.waitForSelector('#app-container', { state: 'visible' });
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test('should load the GIS dashboard without console errors', async () => {
+    // Navigate to the GIS Dashboard
+    await page.click('a[href="#gis-dashboard"]');
+
+    // Wait for the map to be visible
+    await page.waitForSelector('#map', { state: 'visible' });
+
+    // Assert that the map element is present
+    const map = await page.locator('#map');
+    await expect(map).toBeVisible();
+
+    // Check for console errors
+    expect(consoleErrors).toEqual([]);
+  });
+});


### PR DESCRIPTION
The GIS dashboard was failing to load due to a JavaScript error: `Uncaught TypeError: L.GeometryUtil.geodesicArea is not a function`.

This error occurred because the `geodesicArea` function is part of the `Leaflet.draw` plugin, which was not included in the application.

This commit adds the `leaflet.draw` CSS and JavaScript files from a CDN to `royalties.html`.

A new Playwright test has been added to verify that the GIS dashboard loads correctly without console errors.