### PR TITLE
fix(charts): Prevent canvas reuse error on dashboard refresh

### DIFF
--- a/js/modules/ChartManager.js
+++ b/js/modules/ChartManager.js
@@ -480,7 +480,16 @@ export class ChartManager {
         element.appendChild(canvas);
 
         const ctx = canvas.getContext('2d');
-        new Chart(ctx, {
+        const sparklineId = element.id || `sparkline-${[...Array(5)].map(() => Math.random().toString(36)[2]).join('')}`;
+        if (!element.id) {
+            element.id = sparklineId;
+        }
+
+        if (this.charts.has(sparklineId)) {
+            this.charts.get(sparklineId).destroy();
+        }
+
+        const chart = new Chart(ctx, {
             type: 'line',
             data: {
                 labels: ['', '', '', '', '', ''],
@@ -500,6 +509,7 @@ export class ChartManager {
                 elements: { point: { radius: 0 } }
             }
         });
+        this.charts.set(sparklineId, chart);
     }
 
     updateForecastMetrics() {

--- a/tests/gis_dashboard.spec.js
+++ b/tests/gis_dashboard.spec.js
@@ -43,4 +43,21 @@ test.describe('GIS Dashboard', () => {
     // Check for console errors
     expect(consoleErrors).toEqual([]);
   });
+
+  test('should refresh the dashboard without console errors', async () => {
+    // Navigate back to the main dashboard
+    await page.click('a[href="#dashboard"]');
+
+    // Wait for the dashboard to be visible
+    await page.waitForSelector('#dashboard', { state: 'visible' });
+
+    // Click the refresh button
+    await page.click('#refresh-dashboard');
+
+    // Wait for a moment to allow for refresh logic to complete
+    await page.waitForTimeout(1000);
+
+    // Check for console errors
+    expect(consoleErrors).toEqual([]);
+  });
 });


### PR DESCRIPTION
The dashboard was throwing a 'Canvas is already in use' error when refreshed. This was caused by the `createSparkline` function in `ChartManager.js` creating new chart instances on existing canvas elements without destroying the old ones first.

This commit fixes the issue by:
- Modifying `createSparkline` to check for and destroy any existing chart instance on the canvas before creating a new one.
- Storing the sparkline charts in the `this.charts` map to ensure they are properly managed.

A new Playwright test has been added to `tests/gis_dashboard.spec.js` to simulate a dashboard refresh and ensure no console errors occur. This test now passes, confirming the fix.