### PR TITLE
fix(db): Ensure royalty data is seeded on database upgrade

### DIFF
--- a/js/services/database.service.js
+++ b/js/services/database.service.js
@@ -36,20 +36,27 @@ class DatabaseService {
             request.onupgradeneeded = event => {
                 const db = event.target.result;
 
-                // Create stores if they don't exist
+                // Create or get the royalty store
+                let royaltyStore;
                 if (!db.objectStoreNames.contains(this.stores.royalties)) {
-                    const royaltyStore = db.createObjectStore(this.stores.royalties, { keyPath: 'id', autoIncrement: true });
-                    // Seed initial data
-                    const royaltyData = [
-                        { entity: 'Kwalini Quarry', mineral: 'Quarried Stone', volume: 1200, tariff: 15.50, royaltyPayment: 18600, paymentDate: '2025-07-15', status: 'Paid' },
-                        { entity: 'Maloma Colliery', mineral: 'Coal', volume: 5000, tariff: 25.00, royaltyPayment: 125000, paymentDate: '2025-07-10', status: 'Paid' },
-                        { entity: 'Mbabane Quarry', mineral: 'Gravel', volume: 800, tariff: 18.50, royaltyPayment: 14800, paymentDate: '2025-06-20', status: 'Overdue' },
-                        { entity: 'Ngwenya Mine', mineral: 'Iron Ore', volume: 2500, tariff: 30.00, royaltyPayment: 75000, paymentDate: '2025-07-05', status: 'Paid' },
-                        { entity: 'Sidvokodvo Quarry', mineral: 'Gravel', volume: 1500, tariff: 18.50, royaltyPayment: 27750, paymentDate: '2025-05-15', status: 'Overdue' },
-                    ];
-                    royaltyData.forEach(record => royaltyStore.add(record));
+                    royaltyStore = db.createObjectStore(this.stores.royalties, { keyPath: 'id', autoIncrement: true });
+                } else {
+                    royaltyStore = event.target.transaction.objectStore(this.stores.royalties);
                 }
 
+                // Clear existing data and re-seed to ensure a consistent state on upgrade
+                royaltyStore.clear();
+                const royaltyData = [
+                    { entity: 'Kwalini Quarry', mineral: 'Quarried Stone', volume: 1200, tariff: 15.50, royaltyPayment: 18600, paymentDate: '2025-07-15', status: 'Paid' },
+                    { entity: 'Maloma Colliery', mineral: 'Coal', volume: 5000, tariff: 25.00, royaltyPayment: 125000, paymentDate: '2025-07-10', status: 'Paid' },
+                    { entity: 'Mbabane Quarry', mineral: 'Gravel', volume: 800, tariff: 18.50, royaltyPayment: 14800, paymentDate: '2025-06-20', status: 'Overdue' },
+                    { entity: 'Ngwenya Mine', mineral: 'Iron Ore', volume: 2500, tariff: 30.00, royaltyPayment: 75000, paymentDate: '2025-07-05', status: 'Paid' },
+                    { entity: 'Sidvokodvo Quarry', mineral: 'Gravel', volume: 1500, tariff: 18.50, royaltyPayment: 27750, paymentDate: '2025-05-15', status: 'Overdue' },
+                ];
+                royaltyData.forEach(record => royaltyStore.add(record));
+
+
+                // Create other stores if they don't exist
                 if (!db.objectStoreNames.contains(this.stores.users)) {
                     db.createObjectStore(this.stores.users, { keyPath: 'id' });
                 }

--- a/tests/dashboard_navigation.spec.js
+++ b/tests/dashboard_navigation.spec.js
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Dashboard Navigation', () => {
+  let page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    await page.goto('http://localhost:8000/royalties.html');
+
+    // Wait for the login form to be visible
+    await page.waitForSelector('#login-form');
+
+    // Perform login
+    await page.fill('#username', 'admin');
+    await page.fill('#password', 'demo123');
+    await page.click('button[type="submit"]');
+
+    // Wait for the main app container to be visible
+    await page.waitForSelector('#app-container', { state: 'visible' });
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test('should navigate to royalty records when "Total Royalties" card is clicked', async () => {
+    // Click on the "Total Royalties" card
+    await page.click('#dashboard .metric-card:nth-child(1)');
+
+    // Wait for the royalty records section to be visible
+    await page.waitForSelector('#royalty-records', { state: 'visible' });
+
+    // Verify that the royalty records section is visible
+    const royaltyRecordsSection = await page.locator('#royalty-records');
+    await expect(royaltyRecordsSection).toBeVisible();
+
+    // Verify that the table contains the seeded data
+    const tableBody = await page.locator('#royalty-records-tbody');
+    const rows = await tableBody.locator('tr').count();
+    expect(rows).toBeGreaterThan(0);
+
+    // Check for a specific record
+    const kwaliniRecord = await tableBody.locator('tr:has-text("Kwalini Quarry")');
+    await expect(kwaliniRecord).toBeVisible();
+  });
+});


### PR DESCRIPTION
When the "Total Royalties" card on the dashboard was clicked, it would navigate to the royalty records page, but no data would be displayed.

This was caused by the IndexedDB seeding logic in `database.service.js` only running when the `royalties` object store was first created. If the database already existed from a previous version, the data was not seeded, resulting in an empty table.

This commit fixes the issue by modifying the `onupgradeneeded` event handler to clear and re-seed the `royalties` table on every database version upgrade. This ensures a consistent state for the royalty records.

A new Playwright test has been added to `tests/dashboard_navigation.spec.js` to verify that clicking the "Total Royalties" card correctly navigates to the royalty records page and that the data is displayed. This test now passes, confirming the fix.