### PR TITLE
fix(dashboard): Correctly display total royalties value

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1194,7 +1194,7 @@ class App {
         // Update royalty metrics
         const totalRoyaltiesEl = document.getElementById('total-royalties');
         if (totalRoyaltiesEl) {
-            totalRoyaltiesEl.textContent = `E ${royaltyData.totalRoyalties.toLocaleString('en-SZ')}`;
+            totalRoyaltiesEl.textContent = `E ${royaltyData.totalRoyalties.toLocaleString('en-SZ', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
         }
 
         const activeEntitiesEl = document.getElementById('active-entities');

--- a/js/services/database.service.js
+++ b/js/services/database.service.js
@@ -6,7 +6,7 @@
 class DatabaseService {
     constructor() {
         this.dbName = 'RoyaltiesDB';
-        this.version = 3; // Incremented version to trigger upgrade
+        this.version = 4; // Incremented version to trigger upgrade
         this.stores = {
             royalties: 'royalties',
             users: 'users',

--- a/tests/dashboard_navigation.spec.js
+++ b/tests/dashboard_navigation.spec.js
@@ -79,4 +79,15 @@ test.describe('Dashboard Navigation', () => {
     // Check for console errors
     expect(consoleErrors).toEqual([]);
   });
+
+  test('should display the correct total royalties on the dashboard', async () => {
+    // The total from the seed data is 261150
+    const expectedTotal = 'E 261,150.00';
+
+    // Get the text content of the total royalties element
+    const totalRoyaltiesElement = await page.locator('#total-royalties');
+
+    // Wait for the text to be updated, as it might take a moment after login
+    await expect(totalRoyaltiesElement).toHaveText(expectedTotal, { timeout: 10000 });
+  });
 });


### PR DESCRIPTION
The "Total Royalties (YTD)" card on the dashboard was incorrectly displaying "E 0". This was due to two issues:
1. The IndexedDB data was not being seeded correctly on version upgrades, leading to an empty `royalties` table.
2. The number formatting for the total value was not consistently including two decimal places.

This commit fixes these issues by:
- Incrementing the database version to 4 in `database.service.js` to trigger the `onupgradeneeded` event and re-seed the data for all users.
- Updating the `toLocaleString` method in `js/app.js` to always display two decimal places for the total royalties value.

A new Playwright test has been added to `tests/dashboard_navigation.spec.js` to verify that the "Total Royalties" card displays the correct, formatted value on load. All tests now pass.