### PR TITLE
fix(db): Force database upgrade to ensure data seeding

### DIFF
--- a/js/services/database.service.js
+++ b/js/services/database.service.js
@@ -6,7 +6,7 @@
 class DatabaseService {
     constructor() {
         this.dbName = 'RoyaltiesDB';
-        this.version = 4; // Incremented version to trigger upgrade
+        this.version = 5; // Incremented version to trigger upgrade
         this.stores = {
             royalties: 'royalties',
             users: 'users',


### PR DESCRIPTION
The "Total Royalties (YTD)" card on the dashboard was still showing "E 0" for some users, even after a previous fix. This was because their local IndexedDB was at the latest version but did not contain the necessary seed data. The seeding logic only runs on a version upgrade.

This commit forces another database upgrade by incrementing the version number in `js/services/database.service.js` from 4 to 5. This will trigger the `onupgradeneeded` event for all users, clearing the `royalties` object store and re-seeding it with the correct initial data.

This ensures that all users will have a correctly populated database, resolving the issue of the dashboard displaying an incorrect "E 0" value. All existing tests continue to pass, confirming that this change does not introduce any regressions.