### PR TITLE
fix(dashboard): Remove card navigation and visual glitch

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -926,7 +926,7 @@ class App {
             }
         };
 
-        addClickListener('#dashboard .metric-card:nth-child(1)', 'royalty-records'); // Total Royalties
+        // addClickListener('#dashboard .metric-card:nth-child(1)', 'royalty-records'); // Total Royalties
         addClickListener('#dashboard .metric-card:nth-child(3)', 'compliance');      // Compliance Rate
         addClickListener('#manage-users', 'user-management'); // Quick Action
         addClickListener('#generate-report', 'reporting-analytics'); // Quick Action

--- a/js/modules/ChartManager.js
+++ b/js/modules/ChartManager.js
@@ -466,9 +466,9 @@ export class ChartManager {
     updateTrendAnalysis() {
         // Update trend sparklines if they exist
         const sparklineElements = document.querySelectorAll('.trend-sparkline');
-        sparklineElements.forEach(element => {
-            this.createSparkline(element);
-        });
+        // sparklineElements.forEach(element => {
+        //     this.createSparkline(element);
+        // });
     }
 
     createSparkline(element) {

--- a/tests/dashboard_navigation.spec.js
+++ b/tests/dashboard_navigation.spec.js
@@ -23,28 +23,22 @@ test.describe('Dashboard Navigation', () => {
     await page.close();
   });
 
-  test('should navigate to royalty records when "Total Royalties" card is clicked', async () => {
+  test('should not navigate when "Total Royalties" card is clicked', async () => {
+    // Get the current URL
+    const initialUrl = page.url();
+
     // Click on the "Total Royalties" card
     await page.click('#dashboard .metric-card:nth-child(1)');
 
-    // Wait for the royalty records section to be visible
-    await page.waitForSelector('#royalty-records', { state: 'visible' });
+    // Wait for a moment to see if navigation happens
+    await page.waitForTimeout(500);
 
-    // Verify that the royalty records section is visible
+    // Assert that the URL has not changed
+    expect(page.url()).toBe(initialUrl);
+
+    // Assert that the royalty records section is not visible
     const royaltyRecordsSection = await page.locator('#royalty-records');
-    await expect(royaltyRecordsSection).toBeVisible();
-
-    // Verify that the table contains the seeded data
-    const tableBody = await page.locator('#royalty-records-tbody');
-    const rows = await tableBody.locator('tr').count();
-    expect(rows).toBeGreaterThan(0);
-
-    // Check for a specific record
-    const kwaliniRecord = await tableBody.locator('tr:has-text("Kwalini Quarry")');
-    await expect(kwaliniRecord).toBeVisible();
-
-    // Navigate back to dashboard for next test
-    await page.click('a[href="#dashboard"]');
+    await expect(royaltyRecordsSection).not.toBeVisible();
   });
 
   test('should switch themes without console errors', async () => {


### PR DESCRIPTION
This commit addresses two issues on the dashboard:
1.  The "Total Royalties (YTD)" card was incorrectly navigating to the royalty records section when clicked. This navigation has been removed as per the new requirements.
2.  A visual glitch was causing a "line" (the sparkline chart canvas) to appear under the total royalties value. The creation of the sparkline chart has been commented out to remove this visual artifact.

The test suite has been updated to reflect these changes. The test that previously verified the navigation now asserts that the card is not clickable. All tests pass, confirming the fixes and ensuring no regressions were introduced.