### PR TITLE
fix(css): Prevent text wrapping on dashboard metric cards

### DIFF
--- a/royalties.css
+++ b/royalties.css
@@ -1401,6 +1401,7 @@ nav ul li a span.notification-badge {
     color: var(--text-primary);
     margin: 0;
     line-height: 1.1;
+    white-space: nowrap;
 }
 
 .metric-card .card-body small {


### PR DESCRIPTION
The "Total Royalties (YTD)" value on the dashboard was wrapping, causing the currency symbol and the number to appear on separate lines.

This was due to the container being too narrow for the large font size.

This commit adds `white-space: nowrap;` to the CSS rule for the metric card's main value (`.metric-card .card-body p`). This ensures that the value does not wrap, keeping the currency and number on the same line.