### PR TITLE
fix(UserManager): Remove incorrect call to initializeRBAC

### DIFF
--- a/js/modules/UserManager.js
+++ b/js/modules/UserManager.js
@@ -126,12 +126,7 @@ export class UserManager {
   }
 
   async setupRoleBasedAccess() {
-      // Initialize enhanced RBAC system
-      await this.permissionService.initializeRBAC({
-          roles: ['admin', 'manager', 'auditor', 'user'],
-          hierarchical: true,
-          customPermissions: true
-      });
+      // RBAC is initialized in the PermissionService constructor
   }
 
   setupUserActivityMonitoring() {


### PR DESCRIPTION
Removes the call to `this.permissionService.initializeRBAC()` within the `setupRoleBasedAccess` method of `UserManager.js`.

This call was causing a `TypeError` because the `initializeRBAC` method does not exist on the `permissionService` object. The `PermissionService` is designed to initialize its own roles and permissions within its constructor, making the external call from `UserManager` redundant and incorrect.

This change resolves the runtime error and relies on the `PermissionService`'s own initialization, ensuring the Role-Based Access Control system functions as originally designed.