### PR TITLE
fix: Ensure expense tracking chart displays correctly

### DIFF
--- a/js/modules/ChartManager.js
+++ b/js/modules/ChartManager.js
@@ -341,6 +341,28 @@ export class ChartManager {
     this.charts.set("comparative", chart);
   }
 
+  createChart(chartId, canvas, type, data, options = {}) {
+    if (!canvas || typeof Chart === "undefined") return;
+
+    const ctx = canvas.getContext("2d");
+    this.charts.get(chartId)?.destroy();
+
+    const defaultOptions = {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { display: true, position: "top" } },
+    };
+
+    const chart = new Chart(ctx, {
+        type: type,
+        data: data,
+        options: { ...defaultOptions, ...options },
+    });
+
+    this.charts.set(chartId, chart);
+    return chart;
+  }
+
   showFallbackCharts() {
     const containers = ["#revenue-trends-chart", "#production-by-entity-chart"];
     containers.forEach((selector) => {


### PR DESCRIPTION
This commit fixes a bug where the chart in the JIB/Expense Tracking section was not displaying.

The root cause was that the `ChartManager.js` module was missing a generic `createChart` method. The `expense-tracking.js` module was attempting to call this non-existent method, causing the chart rendering to fail silently.

The fix involves:
- Adding a new, generic `createChart` method to `ChartManager.js` that can be used to create new chart instances on demand.
- This new method is now correctly called by the `renderExpenseChart` function in `expense-tracking.js`.

All tests, including those for the expense tracking section, are now passing.