### PR TITLE
feat: Implement 2FA toggle from user management table

### DIFF
--- a/test-enhanced-features.html
+++ b/test-enhanced-features.html
@@ -71,6 +71,9 @@
         <button class="btn btn-warning" id="test-security-service">
           Test Security Service
         </button>
+        <button class="btn btn-danger" id="test-2fa-toggle">
+          Test 2FA Toggle
+        </button>
       </div>
 
       <div
@@ -243,6 +246,52 @@
             logResult("✓ Security event logging works", "success");
           } catch (error) {
             logResult(`✗ Security service error: ${error.message}`, "error");
+          }
+        });
+
+      document
+        .getElementById("test-2fa-toggle")
+        .addEventListener("click", async () => {
+          if (!window.testUserManager) {
+            logResult("✗ User manager not initialized", "error");
+            return;
+          }
+
+          logResult("Testing 2FA toggle button...", "info");
+
+          try {
+            // Find a user to test with
+            const user = window.testUserManager.users[0];
+            if (!user) {
+              logResult("✗ No users found to test", "error");
+              return;
+            }
+
+            const initialStatus = user.twoFactorEnabled;
+            logResult(
+              `Testing with user: ${user.username}, initial 2FA status: ${initialStatus}`,
+            );
+
+            // Simulate the click
+            await window.testUserManager.toggleTwoFactorAuth(user.id);
+
+            // Check the new status
+            const updatedUser = window.testUserManager.getUser(user.id);
+            const newStatus = updatedUser.twoFactorEnabled;
+
+            if (newStatus === !initialStatus) {
+              logResult(
+                `✓ 2FA status successfully toggled to ${newStatus}`,
+                "success",
+              );
+            } else {
+              logResult(
+                `✗ 2FA status did not toggle correctly. Expected ${!initialStatus}, got ${newStatus}`,
+                "error",
+              );
+            }
+          } catch (error) {
+            logResult(`✗ 2FA toggle test failed: ${error.message}`, "error");
           }
         });
 


### PR DESCRIPTION
This commit introduces the ability for administrators to enable or disable Two-Factor Authentication (2FA) for users directly from the main user management table.

Key changes:
- Added a 2FA toggle button to each user row in the `UserManager`.
- The button's appearance (color and title) dynamically reflects the user's current 2FA status.
- Implemented the `toggleTwoFactorAuth` method to handle the logic of updating the user's 2FA status.
- The change is persisted and the UI is updated instantly.
- Security events are logged and notifications are sent upon changing the 2FA status, using the existing `userSecurityService`.
- Added a new test to `test-enhanced-features.html` to verify the functionality of the new 2FA toggle button.