### PR TITLE
Fix: Update GIS multilayer icon to be more descriptive

### DIFF
--- a/css/gis-dashboard-enhanced.css
+++ b/css/gis-dashboard-enhanced.css
@@ -434,7 +434,9 @@
 }
 
 .leaflet-control-layers-toggle::after {
-  content: "☰";
+  content: "\\f5fd"; /* Unicode for fa-layer-group */
+  font-family: "Font Awesome 6 Free";
+  font-weight: 900; /* Required for solid icons */
   font-size: 16px;
   color: white;
 }


### PR DESCRIPTION
The previous icon for the GIS multilayer button was a generic hamburger icon, which did not accurately represent its function. This change updates the icon to use the `fa-layer-group` icon from Font Awesome, providing a more intuitive user experience. The CSS is updated to use the escaped unicode sequence for the icon to prevent rendering issues.