### PR TITLE
Fix Chart.js module resolution error

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -31,11 +31,6 @@ import RoyaltyRecords from "./modules/royalty-records.js";
 import { GisDashboard } from "./modules/GisDashboard.js";
 import { AuditLogManager } from "./modules/AuditLogManager.js";
 import { PasswordPolicyManager } from "./modules/PasswordPolicyManager.js";
-import { TimeScale,TimeSeriesScale } from 'chart.js';
-import Chart from 'chart.js/auto';
-
-
-Chart.register(TimeScale, TimeSeriesScale);
 
 class App {
   constructor() {
@@ -1653,5 +1648,9 @@ class App {
 
 // Initialize application when DOM is loaded
 document.addEventListener("DOMContentLoaded", () => {
+  if (window.Chart) {
+    const { TimeScale, TimeSeriesScale } = window.Chart;
+    window.Chart.register(TimeScale, TimeSeriesScale);
+  }
   window.app = new App();
 });


### PR DESCRIPTION
This commit fixes a bug where the application would fail to load if `royalties.html` was opened directly in the browser. The error was caused by an ES module import of `chart.js` in `js/app.js` which the browser could not resolve without a dev server.

The fix involves:
- Removing the `import` statements for `chart.js` from `js/app.js`.
- Relying on the global `Chart` object provided by the CDN script in `royalties.html`.
- Moving the `Chart.register(TimeScale, TimeSeriesScale)` call to a `DOMContentLoaded` event listener to ensure it runs after the `Chart` object is available.