### PR TITLE
Fix: Resolve Chart.js module loading error

### DIFF
--- a/royalties.html
+++ b/royalties.html
@@ -44,7 +44,14 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet-geometryutil@0.10.1/src/leaflet.geometryutil.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.js"></script>
     <script src="js/bcrypt.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script type="importmap">
+      {
+        "imports": {
+          "chart.js": "https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.mjs",
+          "chartjs-adapter-date-fns": "https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.esm.js"
+        }
+      }
+    </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
     <script src="https://unpkg.com/jspdf@latest/dist/jspdf.umd.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>


### PR DESCRIPTION
The application was failing to load charts due to an `Uncaught TypeError: Failed to resolve module specifier "chart.js"`.

This was caused by using a bare module specifier in JavaScript `import` statements without a mechanism for the browser to resolve it.

This commit replaces the legacy script tag for Chart.js with a modern `importmap`. The import map tells the browser how to resolve the module specifiers for `chart.js` and `chartjs-adapter-date-fns` to their respective CDN URLs, allowing the application to load the modules correctly.