### PR TITLE
fix: Correct Chart.js CDN URL in royalties.html

### DIFF
--- a/royalties.html
+++ b/royalties.html
@@ -47,7 +47,7 @@
     <script type="importmap">
       {
         "imports": {
-          "chart.js": "https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.mjs",
+          "chart.js": "https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.js",
           "chartjs-adapter-date-fns": "https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.esm.js"
         }
       }


### PR DESCRIPTION
The application was failing to load Chart.js due to an incorrect URL in the importmap. This change corrects the URL from '.../chart.mjs' to '.../chart.js', which resolves the 404 error.